### PR TITLE
Adding dark theme

### DIFF
--- a/data/themes/dark/1mines.svg
+++ b/data/themes/dark/1mines.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg id="svg3767" width="64" height="64" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata id="metadata3772">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <g id="layer1" transform="translate(0 -988.36)">
+  <text id="text4299" transform="translate(0 988.36)" x="28.284271" y="32.685272" style="fill:#000000;font-family:Cantarell;font-size:20px;letter-spacing:0px;line-height:125%;word-spacing:0px" xml:space="preserve"><tspan id="tspan4301" x="28.284271" y="32.685272"/></text>
+  <text id="text4303" x="8.7441406" y="1046.6063" style="fill:#adadad;font-family:Cantarell;font-size:20px;letter-spacing:0px;line-height:125%;word-spacing:0px" xml:space="preserve"><tspan id="tspan4305" x="8.7441406" y="1046.6063" style="fill:#adadad;font-family:Monospace;font-size:72px;font-weight:bold">1</tspan></text>
+ </g>
+</svg>

--- a/data/themes/dark/2mines.svg
+++ b/data/themes/dark/2mines.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg id="svg3767" width="64" height="64" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata id="metadata3772">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <g id="layer1" transform="translate(0 -988.36)">
+  <text id="text4299" transform="translate(0 988.36)" x="28.284271" y="32.685272" style="fill:#000000;font-family:Cantarell;font-size:20px;letter-spacing:0px;line-height:125%;word-spacing:0px" xml:space="preserve"><tspan id="tspan4301" x="28.284271" y="32.685272"/></text>
+  <text id="text4303" x="11.292969" y="1047.0809" style="fill:#adadad;font-family:Cantarell;font-size:20px;letter-spacing:0px;line-height:125%;word-spacing:0px" xml:space="preserve"><tspan id="tspan4305" x="11.292969" y="1047.0809" style="fill:#adadad;font-family:Monospace;font-size:72px;font-weight:bold">2</tspan></text>
+ </g>
+</svg>

--- a/data/themes/dark/3mines.svg
+++ b/data/themes/dark/3mines.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg id="svg3767" width="64" height="64" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata id="metadata3772">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <g id="layer1" transform="translate(0 -988.36)">
+  <text id="text4299" transform="translate(0 988.36)" x="28.284271" y="32.685272" style="fill:#000000;font-family:Cantarell;font-size:20px;letter-spacing:0px;line-height:125%;word-spacing:0px" xml:space="preserve"><tspan id="tspan4301" x="28.284271" y="32.685272"/></text>
+  <text id="text4303" x="10.466797" y="1046.5712" style="fill:#adadad;font-family:Cantarell;font-size:20px;letter-spacing:0px;line-height:125%;word-spacing:0px" xml:space="preserve"><tspan id="tspan4305" x="10.466797" y="1046.5712" style="fill:#adadad;font-family:Monospace;font-size:72px;font-weight:bold">3</tspan></text>
+ </g>
+</svg>

--- a/data/themes/dark/4mines.svg
+++ b/data/themes/dark/4mines.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg id="svg3767" width="64" height="64" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata id="metadata3772">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <g id="layer1" transform="translate(0 -988.36)">
+  <text id="text4299" transform="translate(0 988.36)" x="28.284271" y="32.685272" style="fill:#000000;font-family:Cantarell;font-size:20px;letter-spacing:0px;line-height:125%;word-spacing:0px" xml:space="preserve"><tspan id="tspan4301" x="28.284271" y="32.685272"/></text>
+  <text id="text4303" x="10.150391" y="1046.6063" style="fill:#adadad;font-family:Cantarell;font-size:20px;letter-spacing:0px;line-height:125%;word-spacing:0px" xml:space="preserve"><tspan id="tspan4305" x="10.150391" y="1046.6063" style="fill:#adadad;font-family:Monospace;font-size:72px;font-weight:bold">4</tspan></text>
+ </g>
+</svg>

--- a/data/themes/dark/5mines.svg
+++ b/data/themes/dark/5mines.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg id="svg3767" width="64" height="64" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata id="metadata3772">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <g id="layer1" transform="translate(0 -988.36)">
+  <text id="text4299" transform="translate(0 988.36)" x="28.284271" y="32.685272" style="fill:#000000;font-family:Cantarell;font-size:20px;letter-spacing:0px;line-height:125%;word-spacing:0px" xml:space="preserve"><tspan id="tspan4301" x="28.284271" y="32.685272"/></text>
+  <text id="text4303" x="10.255859" y="1046.0966" style="fill:#adadad;font-family:Cantarell;font-size:20px;letter-spacing:0px;line-height:125%;word-spacing:0px" xml:space="preserve"><tspan id="tspan4305" x="10.255859" y="1046.0966" style="fill:#adadad;font-family:Monospace;font-size:72px;font-weight:bold">5</tspan></text>
+ </g>
+</svg>

--- a/data/themes/dark/6mines.svg
+++ b/data/themes/dark/6mines.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg id="svg3767" width="64" height="64" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata id="metadata3772">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <g id="layer1" transform="translate(0 -988.36)">
+  <text id="text4299" transform="translate(0 988.36)" x="28.284271" y="32.685272" style="fill:#000000;font-family:Cantarell;font-size:20px;letter-spacing:0px;line-height:125%;word-spacing:0px" xml:space="preserve"><tspan id="tspan4301" x="28.284271" y="32.685272"/></text>
+  <text id="text4303" x="9.9746094" y="1046.5009" style="fill:#adadad;font-family:Cantarell;font-size:20px;letter-spacing:0px;line-height:125%;word-spacing:0px" xml:space="preserve"><tspan id="tspan4305" x="9.9746094" y="1046.5009" style="fill:#adadad;font-family:Monospace;font-size:72px;font-weight:bold">6</tspan></text>
+ </g>
+</svg>

--- a/data/themes/dark/7mines.svg
+++ b/data/themes/dark/7mines.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg id="svg3767" width="64" height="64" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata id="metadata3772">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <g id="layer1" transform="translate(0 -988.36)">
+  <text id="text4299" transform="translate(0 988.36)" x="28.284271" y="32.685272" style="fill:#000000;font-family:Cantarell;font-size:20px;letter-spacing:0px;line-height:125%;word-spacing:0px" xml:space="preserve"><tspan id="tspan4301" x="28.284271" y="32.685272"/></text>
+  <text id="text4303" x="10.660156" y="1046.6063" style="fill:#adadad;font-family:Cantarell;font-size:20px;letter-spacing:0px;line-height:125%;word-spacing:0px" xml:space="preserve"><tspan id="tspan4305" x="10.660156" y="1046.6063" style="fill:#adadad;font-family:Monospace;font-size:72px;font-weight:bold">7</tspan></text>
+ </g>
+</svg>

--- a/data/themes/dark/8mines.svg
+++ b/data/themes/dark/8mines.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg id="svg3767" width="64" height="64" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata id="metadata3772">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <g id="layer1" transform="translate(0 -988.36)">
+  <text id="text4299" transform="translate(0 988.36)" x="28.284271" y="32.685272" style="fill:#000000;font-family:Cantarell;font-size:20px;letter-spacing:0px;line-height:125%;word-spacing:0px" xml:space="preserve"><tspan id="tspan4301" x="28.284271" y="32.685272"/></text>
+  <text id="text4303" x="10.326172" y="1046.5712" style="fill:#adadad;font-family:Cantarell;font-size:20px;letter-spacing:0px;line-height:125%;word-spacing:0px" xml:space="preserve"><tspan id="tspan4305" x="10.326172" y="1046.5712" style="fill:#adadad;font-family:Monospace;font-size:72px;font-weight:bold">8</tspan></text>
+ </g>
+</svg>

--- a/data/themes/dark/exploded.svg
+++ b/data/themes/dark/exploded.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="svg1" width="64" height="64" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata id="metadata23">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <path id="path2999" transform="matrix(1.4,0,0,1.4,-1074,-577)" d="m805 435a15 15 0 1 1-30 0 15 15 0 1 1 30 0z" style="fill:#c00"/>
+ <rect id="rect3001" x="28" width="8" height="64" rx="4.6" ry="4.6" style="fill:#c00"/>
+ <rect id="rect3013" transform="matrix(.5 .86603 -.86603 .5 0 0)" x="39.713" y="-43.713" width="8" height="64" rx="4.6" ry="4.6" style="fill:#c00"/>
+ <rect id="rect3015" transform="matrix(-.5 .86603 -.86603 -.5 0 0)" x="7.7128" y="-75.713" width="8" height="64" rx="4.6" ry="4.6" style="fill:#c00"/>
+</svg>

--- a/data/themes/dark/flag.svg
+++ b/data/themes/dark/flag.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="svg9373" width="64" height="64" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata id="metadata9418">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <path id="path9621" d="m8.0863 0.17502 8.9985-0.17502v3.1041l41.02 17.637-41.064 17.637-0.043176 25.622h-8.9973z" style="fill:#adadad"/>
+</svg>

--- a/data/themes/dark/incorrect.svg
+++ b/data/themes/dark/incorrect.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="svg9373" width="64" height="64" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata id="metadata9418">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <path id="path9621" d="m8.0863 0.17502 8.9985-0.17502v3.1041l41.02 17.637-41.064 17.637-0.043176 25.622h-8.9973z" style="fill:#c00"/>
+</svg>

--- a/data/themes/dark/maybe.svg
+++ b/data/themes/dark/maybe.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="svg9373" width="64" height="64" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata id="metadata9418">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <path id="path9621" d="m8.0863 0.17502 8.9985-0.17502v3.1041l41.02 17.637-41.064 17.637-0.043176 25.622h-8.9973z" style="fill:#adadad"/>
+ <g id="g15007" transform="matrix(2.7979 0 0 2.7979 -223.49 -253.48)" style="fill:#2e3436">
+  <path id="path15009" d="m97.348 103.47c1.6424-0.092 3.0955 1.1701 3.1875 2.8125-1e-4 1.4014-0.37771 1.9218-1.5937 2.8438-0.19093 0.14364-0.3256 0.2506-0.375 0.3125-0.0494 0.0621-0.0312 0.0332-0.0312 0.0312 7e-3 0.52831-0.47163 1-1 1s-1.007-0.47169-1-1c0-0.50239 0.22424-0.94342 0.46875-1.25 0.24451-0.30663 0.4913-0.51638 0.71875-0.6875 0.20405-0.16056 0.46083-0.38454 0.6875-0.65625 0.0935-0.1121 0.129-0.30766 0.125-0.4375v-0.0312c-0.0316-0.56324-0.49926-0.9691-1.0625-0.9375s-0.9691 0.43676-0.9375 1h-2c-0.092-1.6424 1.1701-2.9079 2.8125-3zm0.1875 8c0.55228 0 1 0.44772 1 1s-0.44772 1-1 1-1-0.44772-1-1 0.44772-1 1-1z" style="color:#bebebe;fill:#adadad"/>
+ </g>
+</svg>

--- a/data/themes/dark/mine.svg
+++ b/data/themes/dark/mine.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="svg1" width="64" height="64" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata id="metadata23">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <path id="path2999" transform="matrix(1.4,0,0,1.4,-1074,-577)" d="m805 435a15 15 0 1 1-30 0 15 15 0 1 1 30 0z" style="fill:#212121"/>
+ <rect id="rect3001" x="28" width="8" height="64" rx="4.6" ry="4.6" style="fill:#212121"/>
+ <rect id="rect3013" transform="matrix(.5 .86603 -.86603 .5 0 0)" x="39.713" y="-43.713" width="8" height="64" rx="4.6" ry="4.6" style="fill:#212121"/>
+ <rect id="rect3015" transform="matrix(-.5 .86603 -.86603 -.5 0 0)" x="7.7128" y="-75.713" width="8" height="64" rx="4.6" ry="4.6" style="fill:#212121"/>
+</svg>

--- a/data/themes/dark/theme.css
+++ b/data/themes/dark/theme.css
@@ -1,0 +1,207 @@
+.pausedOverlay {
+  background-color: #212121;
+  color: white;
+  font-size: 32px;
+  border-radius: 3px;
+}
+
+.pausedOverlay:backdrop {
+  background-color: #212121;
+}
+
+.count, .explodedField .tile {
+-gtk-icon-effect: none;
+}
+
+.navigation {
+  border-radius: 32px;
+  background-color: alpha(#888a85, .1);
+  border-width: 0px;
+  border-color: #BABABA;
+  background-image: none;
+}
+
+/* These are the default style settings possibly overridden by themes */
+
+/* Common style for all tiles */
+.tile {
+  background-image: none;
+  background-color: #212121;
+  border-color:@theme_bg_color;
+  border-radius: 4px; /* border width might be affecting */
+  color: transparent;
+  border-image: none;
+  font-size: 16px;
+  font-weight: bold;
+  background-size: 80%;
+  background-position: 50%;
+  padding: 4px;
+  background-origin: content-box;
+  background-repeat: no-repeat;
+  box-shadow: none;
+  border-width: 2px;
+}
+
+.tile:not(.cursor):hover {
+  background-color: #444444;
+}
+
+
+.tile:active {
+  background-color: #888a85;
+  box-shadow: inset 0 2px 1px rgba(0, 0, 0, .2);
+}
+
+/* Style for revealed fields showing numbers */
+.count {
+  color: black;
+  font-size: 0px;
+  background-image: none;
+  background-color: #777777;
+}
+
+.mine {
+  background-image: -gtk-icontheme('mine');
+}
+
+.flag {
+  background-image: -gtk-icontheme('flag');
+}
+
+.incorrect {
+  background-image: -gtk-icontheme('incorrect');
+}
+
+.maybe {
+  background-image: -gtk-icontheme('maybe');
+}
+
+.exploded {
+  background-image: -gtk-icontheme('exploded');
+}
+
+.1mines {
+  background-image: -gtk-icontheme('1mines');
+}
+
+.2mines {
+  background-image: -gtk-icontheme('2mines');
+}
+
+.3mines {
+  background-image: -gtk-icontheme('3mines');
+}
+
+.4mines {
+  background-image: -gtk-icontheme('4mines');
+}
+
+.5mines {
+  background-image: -gtk-icontheme('5mines');
+}
+
+.6mines {
+  background-image: -gtk-icontheme('6mines');
+}
+
+.7mines {
+  background-image: -gtk-icontheme('7mines');
+}
+
+.8mines {
+  background-image: -gtk-icontheme('8mines');
+}
+
+.count:not(.cursor):hover {
+  background-color: #777777;
+}
+
+/* Style for mines */
+.mine {
+  background-color: #729fcf;
+}
+
+/* Style of the keyboard cursor */
+.cursor {
+  background-color: #e9b96e;
+}
+
+/* Styles to be used on game over*/
+.explodedField .incorrect {
+  background-color: #cc0000;
+}
+
+/* Style of the unrevealed tiles after game over */
+.explodedField .mine {
+  background-color: #888a85;
+}
+
+.explodedField .exploded {
+  background-color: #d3d7cf;
+}
+
+.1mines .cursor{
+  background-color: shade(#DDFAC3, 0.5);
+}
+
+.2mines .cursor{
+  background-color: shade(#ECEDBF, 0.5);
+}
+
+.3mines .cursor{
+  background-color: shade(#EDDAB4, 0.5);
+}
+
+.4mines .cursor{
+  background-color: shade(#EDC38A, 0.5);
+}
+
+.5mines .cursor{
+  background-color: shade(#F7A1A2, 0.5);
+}
+
+.6mines .cursor{
+  background-color: shade(#FEA785, 0.5);
+}
+
+.7mines .cursor{
+  background-color: shade(#FF7D60, 0.5);
+}
+
+.8mines .cursor{
+  background-color: shade(#FF323C, 0.5);
+}
+
+.1mines:not(.cursor) {
+  background-color: shade(#DDFAC3, 0.4);
+}
+
+.2mines:not(.cursor) {
+  background-color: shade(#ECEDBF, 0.4);
+}
+
+.3mines:not(.cursor) {
+  background-color: shade(#EDDAB4, 0.4);
+}
+
+.4mines:not(.cursor) {
+  background-color: shade(#EDC38A, 0.4);
+}
+
+.5mines:not(.cursor) {
+  background-color: shade(#F7A1A2, 0.4);
+}
+
+.6mines:not(.cursor) {
+  background-color: shade(#FEA785, 0.4);
+}
+
+.7mines:not(.cursor) {
+  background-color: shade(#FF7D60, 0.4);
+}
+
+.8mines:not(.cursor) {
+  background-color: shade(#FF323C, 0.4);
+}
+
+


### PR DESCRIPTION
Adding soothing dark theme for GNOME mines. Very useful for people with sensitive eyes. Absolutely essential in my opinion.

<img src="https://raw.githubusercontent.com/Avanatiker/GNOME-mines-dark-mode/main/screenshot.png"/>

https://github.com/Avanatiker/GNOME-mines-dark-mode